### PR TITLE
Limit dropdowns to months/years available in Excel

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,7 @@ see how much a given amount of money would be worth in another time period.
 The CPI values are loaded dynamically from the `CPI-Jan13-To-May25.xlsx` file.
 These values are approximate and meant for demonstration purposes only.
 
+The month and year dropdowns are populated from the Excel data, so they match
+the available range (January&nbsp;2013 to May&nbsp;2025 in the provided file).
+
 Open `index.html` in your browser to use the calculator.

--- a/app.js
+++ b/app.js
@@ -15,6 +15,23 @@ const months = [
 
 let cpiData = {};
 
+function updateMonthOptions(year, select, defaultToEnd = false) {
+  const current = select.value;
+  select.innerHTML = "";
+  const available = months.filter((m) => cpiData[year] && cpiData[year][m] !== undefined);
+  available.forEach((m) => {
+    const opt = document.createElement("option");
+    opt.textContent = m;
+    select.appendChild(opt);
+  });
+  if (available.length === 0) return;
+  if (available.includes(current)) {
+    select.value = current;
+  } else {
+    select.value = defaultToEnd ? available[available.length - 1] : available[0];
+  }
+}
+
 async function loadCpiData() {
   const res = await fetch("CPI-Jan13-To-May25.xlsx");
   const buffer = await res.arrayBuffer();
@@ -45,17 +62,8 @@ function populateSelects() {
   const startYearSel = document.getElementById("start-year");
   const endYearSel = document.getElementById("end-year");
 
-  months.forEach((m) => {
-    const opt1 = document.createElement("option");
-    opt1.textContent = m;
-    startMonthSel.appendChild(opt1);
-
-    const opt2 = document.createElement("option");
-    opt2.textContent = m;
-    endMonthSel.appendChild(opt2);
-  });
-
-  Object.keys(cpiData).forEach((year) => {
+  const years = Object.keys(cpiData).sort();
+  years.forEach((year) => {
     const opt1 = document.createElement("option");
     opt1.textContent = year;
     startYearSel.appendChild(opt1);
@@ -65,10 +73,19 @@ function populateSelects() {
     endYearSel.appendChild(opt2);
   });
 
-  startMonthSel.value = "January";
-  endMonthSel.value = "January";
-  startYearSel.value = Object.keys(cpiData)[0];
-  endYearSel.value = Object.keys(cpiData)[Object.keys(cpiData).length - 1];
+  startYearSel.value = years[0];
+  endYearSel.value = years[years.length - 1];
+
+  updateMonthOptions(startYearSel.value, startMonthSel);
+  updateMonthOptions(endYearSel.value, endMonthSel, true);
+
+  startYearSel.addEventListener("change", () => {
+    updateMonthOptions(startYearSel.value, startMonthSel);
+  });
+
+  endYearSel.addEventListener("change", () => {
+    updateMonthOptions(endYearSel.value, endMonthSel, true);
+  });
 }
 
 function calculate() {


### PR DESCRIPTION
## Summary
- dynamically populate dropdowns based on the CPI spreadsheet
- mention the dynamic ranges in the readme

## Testing
- `npm init -y` *(fails: internet disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68625808e6288332a2ae8d3eb400a871