### PR TITLE
Fix CPI dropdown population

### DIFF
--- a/app.js
+++ b/app.js
@@ -42,7 +42,7 @@ async function loadCpiData() {
   const header = rows[headerRowIndex];
   const yearCol = header.indexOf("Year");
   const monthCol = header.indexOf("Month");
-  const indexCol = header.indexOf("IndexValue");
+  const indexCol = header.indexOf("Combined");
   for (let i = headerRowIndex + 1; i < rows.length; i++) {
     const row = rows[i];
     if (!row || row.length === 0) continue;


### PR DESCRIPTION
## Summary
- fix the column name used when reading the CPI Excel sheet

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_68625d7c01088332a870e2cda3932960